### PR TITLE
Fix code and deprecate run_app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,16 @@ SHELL := /bin/bash
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: dependencies
+dependencies: ## Create the lib for dependencies
+	pip install -t lib/ -r requirements.txt
+
 .PHONY: test
 test: ## Run all tests
 	./scripts/run_tests.sh
 
 .PHONY: run
-run: ## Run app
+run: ## Run app - deprecated - use dev-server instead
 	./scripts/run_app.sh
 
 .PHONY: dev-server

--- a/app/clients/__init__.py
+++ b/app/clients/__init__.py
@@ -52,7 +52,7 @@ class BaseAPIClient(object):
             api_error = HTTPError.create(e)
             current_app.logger.error(
                 "Set access token: {} failed with {} '{}'".format(
-                    url,
+                    auth_url,
                     api_error.status_code,
                     api_error.message
                 )

--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,7 @@ def get_setting(name):
 class Config(object):
     DEBUG = False
     API_BASE_URL = get_setting('API_BASE_URL')
-    FRONTEND_BASE_URL = os.environ.get('FRONTEND_BASE_URL')
+    FRONTEND_BASE_URL = get_setting('FRONTEND_BASE_URL')
     ADMIN_CLIENT_ID = get_setting('ADMIN_CLIENT_ID')
     ADMIN_CLIENT_SECRET = get_setting('ADMIN_CLIENT_SECRET')
     SECRET_KEY = get_setting('SECRET_KEY')

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set +e
 
+echo "Deprecated -- use make dev-server instead"
+
 ENV=development
 www_dir="www-$ENV"
 
-port=5100
+port=5050
 
 if [ ! -z "$1" ]; then
     www_dir="www-$1"


### PR DESCRIPTION
url doesn't exist in client init, should be auth_url

run_app.sh has been deprecated, as now using `make dev-server` to run things locally.